### PR TITLE
Add option to teach all spells on first login.

### DIFF
--- a/conf/mod_learnspells.conf.dist
+++ b/conf/mod_learnspells.conf.dist
@@ -12,6 +12,12 @@ LearnSpells.Enable = 1
 
 LearnSpells.Announce = 1
 
+# Should the player receive all spells on first login?
+# Useful for instant leveling type of servers
+# (1: true | 0: false)
+
+LearnSpells.LearnAllOnFirstLogin = 0
+
 # Max level Limit the player will learn spells
 # 	Default:  = 80
 

--- a/src/mod_learnspells.cpp
+++ b/src/mod_learnspells.cpp
@@ -10,52 +10,48 @@ uint32 MaxLevel;
 class LearnSpellsOnLevelUp : public PlayerScript
 {
 public:
-    std::vector<uint32> ignoreSpells;
+    std::unordered_set<uint32> ignoreSpells = {
+        64380, 23885, 23880, 44461, 25346, 10274, 10273, 8418,
+        8419, 7270, 7269, 7268, 54648, 12536, 24530, 70909,
+        12494, 57933, 24224, 27095, 27096, 27097, 27099, 32841,
+        56131, 56160, 56161, 48153, 34754, 64844, 64904, 48085,
+        33110, 48084, 28276, 27874, 27873, 7001, 49821, 53022,
+        47757, 47750, 47758, 47666, 53001, 52983, 52998, 52986,
+        52987, 52999, 52984, 53002, 53003, 53000, 52988, 52985,
+        42208, 42209, 42210, 42211, 42212, 42213, 42198, 42937,
+        42938, 12484, 12485, 12486, 44461, 55361, 55362, 34913,
+        43043, 43044, 38703, 38700, 27076, 42844, 42845, 64891,
+        25912, 25914, 25911, 25913, 25902, 25903, 27175, 27176,
+        33073, 33074, 48822, 48820, 48823, 48821, 20154, 25997,
+        20467, 20425, 67, 26017, 34471, 53254, 13812, 14314,
+        14315, 27026, 49064, 49065, 60202, 60210, 13797, 14298,
+        14299, 14300, 14301, 27024, 49053, 49054, 52399, 1742,
+        24453, 53548, 53562, 52016, 26064, 35346, 57386, 57389,
+        57390, 57391, 57392, 57393, 55509, 35886, 43339, 45297,
+        45298, 45299, 45300, 45301, 45302, 49268, 49269, 8349,
+        8502, 8503, 11306, 11307, 25535, 25537, 61650, 61654,
+        63685, 45284, 45286, 45287, 45288, 45289, 45290, 45291,
+        45292, 45293, 45294, 45295, 45296, 49239, 49240, 26364,
+        26365, 26366, 26367, 26369, 26370, 26363, 26371, 26372,
+        49278, 49279, 32176, 32175, 21169, 47206, 27285, 47833,
+        47836, 42223, 42224, 42225, 42226, 42218, 47817, 47818,
+        42231, 42232, 42233, 42230, 48466, 44203, 44205, 44206,
+        44207, 44208, 48444, 48445, 33891, 52374, 57532, 59921,
+        52372, 49142, 52375, 47633, 47632, 52373, 50536, 27214,
+        47822, 11682, 11681, 5857, 1010, 24907, 24905, 53227,
+        61391, 61390, 61388, 61387, 64801, 5421, 9635, 1178,
+        20186, 20185, 20184, 20187, 25899, 24406, 50581, 30708,
+        48076, 62900, 62901, 62902, 59671, 50589, 66906, 66907,
+        24131, 23455, 23458, 23459, 27803, 27804, 27805, 25329,
+        48075, 42243, 42244, 42245, 42234, 58432, 58433, 65878,
+        18848, 16979, 49376, 54055, 20647, 42243, 24131
+    };
 
     LearnSpellsOnLevelUp() : PlayerScript("LearnSpellsOnLevelUp")
     {
-        uint32 temp[] =
-        {
-            64380, 23885, 23880, 44461, 25346, 10274, 10273, 8418,
-            8419, 7270, 7269, 7268, 54648, 12536, 24530, 70909,
-            12494, 57933, 24224, 27095, 27096, 27097, 27099, 32841,
-            56131, 56160, 56161, 48153, 34754, 64844, 64904, 48085,
-            33110, 48084, 28276, 27874, 27873, 7001, 49821, 53022,
-            47757, 47750, 47758, 47666, 53001, 52983, 52998, 52986,
-            52987, 52999, 52984, 53002, 53003, 53000, 52988, 52985,
-            42208, 42209, 42210, 42211, 42212, 42213, 42198, 42937,
-            42938, 12484, 12485, 12486, 44461, 55361, 55362, 34913,
-            43043, 43044, 38703, 38700, 27076, 42844, 42845, 64891,
-            25912, 25914, 25911, 25913, 25902, 25903, 27175, 27176,
-            33073, 33074, 48822, 48820, 48823, 48821, 20154, 25997,
-            20467, 20425, 67, 26017, 34471, 53254, 13812, 14314,
-            14315, 27026, 49064, 49065, 60202, 60210, 13797, 14298,
-            14299, 14300, 14301, 27024, 49053, 49054, 52399, 1742,
-            24453, 53548, 53562, 52016, 26064, 35346, 57386, 57389,
-            57390, 57391, 57392, 57393, 55509, 35886, 43339, 45297,
-            45298, 45299, 45300, 45301, 45302, 49268, 49269, 8349,
-            8502, 8503, 11306, 11307, 25535, 25537, 61650, 61654,
-            63685, 45284, 45286, 45287, 45288, 45289, 45290, 45291,
-            45292, 45293, 45294, 45295, 45296, 49239, 49240, 26364,
-            26365, 26366, 26367, 26369, 26370, 26363, 26371, 26372,
-            49278, 49279, 32176, 32175, 21169, 47206, 27285, 47833,
-            47836, 42223, 42224, 42225, 42226, 42218, 47817, 47818,
-            42231, 42232, 42233, 42230, 48466, 44203, 44205, 44206,
-            44207, 44208, 48444, 48445, 33891, 52374, 57532, 59921,
-            52372, 49142, 52375, 47633, 47632, 52373, 50536, 27214,
-            47822, 11682, 11681, 5857, 1010, 24907, 24905, 53227,
-            61391, 61390, 61388, 61387, 64801, 5421, 9635, 1178,
-            20186, 20185, 20184, 20187, 25899, 24406, 50581, 30708,
-            48076, 62900, 62901, 62902, 59671, 50589, 66906, 66907,
-            24131, 23455, 23458, 23459, 27803, 27804, 27805, 25329,
-            48075, 42243, 42244, 42245, 42234, 58432, 58433, 65878,
-            18848, 16979, 49376, 54055, 20647, 42243, 24131
-        };
-
-        ignoreSpells = std::vector<uint32>(temp, temp + sizeof(temp) / sizeof(temp[0]));
     }
 
-    void OnLogin(Player *player)
+    void OnLogin(Player *player) override
     {
         if (sConfigMgr->GetBoolDefault("LearnSpells.Enable", true))
         {
@@ -66,7 +62,15 @@ public:
         }
     }
 
-    void OnLevelChanged(Player* player, uint8 oldLevel)
+    void OnFirstLogin(Player *player) override
+    {
+        if (sConfigMgr->GetBoolDefault("LearnSpells.LearnAllOnFirstLogin", false))
+        {
+            LearnSpellsForNewLevel(player, 1);
+        }
+    }
+
+    void OnLevelChanged(Player *player, uint8 oldLevel) override
     {
         if (sConfigMgr->GetBoolDefault("LearnSpells.Enable", true))
         {
@@ -80,13 +84,11 @@ public:
 
     bool IsIgnoredSpell(uint32 spellID)
     {
-        for (std::vector<uint32>::const_iterator itr = ignoreSpells.begin(); itr != ignoreSpells.end(); ++itr)
-            if (spellID == (*itr))
-                return true;
-        return false;
+        auto spellIt = ignoreSpells.find(spellID);
+        return spellIt != ignoreSpells.end();
     }
 
-    void LearnSpellsForNewLevel(Player* player, uint8 level)
+    void LearnSpellsForNewLevel(Player *player, uint8 level)
     {
         if (level == player->getLevel() + 1)
             return;
@@ -126,22 +128,22 @@ public:
         }
         for (uint32 i = 0; i < sSpellMgr->GetSpellInfoStoreSize(); ++i)
         {
-            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(i);
+            SpellInfo const *spellInfo = sSpellMgr->GetSpellInfo(i);
             if (!spellInfo)
                 continue;
             if (spellInfo->SpellFamilyName != family)
                 continue;
-            if (IsIgnoredSpell(spellInfo->Id))
+            if ((spellInfo->AttributesEx7 & SPELL_ATTR7_ALLIANCE_ONLY && player->GetTeamId() != TEAM_ALLIANCE) || (spellInfo->AttributesEx7 & SPELL_ATTR7_HORDE_ONLY && player->GetTeamId() != TEAM_HORDE))
                 continue;
             if (spellInfo->PowerType == POWER_FOCUS)
                 continue;
-            if (DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, spellInfo->Id, player))
+            if (IsIgnoredSpell(spellInfo->Id))
                 continue;
-            if ((spellInfo->AttributesEx7 & SPELL_ATTR7_ALLIANCE_ONLY && player->GetTeamId() != TEAM_ALLIANCE) || (spellInfo->AttributesEx7 & SPELL_ATTR7_HORDE_ONLY && player->GetTeamId() != TEAM_HORDE))
+            if (DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, spellInfo->Id, player))
                 continue;
             if (spellInfo->BaseLevel != level && sSpellMgr->IsSpellValid(spellInfo))
                 continue;
-
+                
             bool valid = false;
 
             SkillLineAbilityMapBounds bounds = sSpellMgr->GetSkillLineAbilityMapBounds(spellInfo->Id);
@@ -150,7 +152,7 @@ public:
                 if (itr->second->spellId == spellInfo->Id && itr->second->racemask == 0 && itr->second->learnOnGetSkill == 0)
                 {
                     valid = true;
-                    SpellInfo const* prevSpell = spellInfo->GetPrevRankSpell();
+                    SpellInfo const *prevSpell = spellInfo->GetPrevRankSpell();
                     if (prevSpell && !player->HasSpell(prevSpell->Id))
                     {
                         valid = false;
@@ -173,11 +175,12 @@ public:
 class LearnAllSpellsWorld : public WorldScript
 {
 public:
-    LearnAllSpellsWorld() : WorldScript("LearnAllSpellsWorld") { }
+    LearnAllSpellsWorld() : WorldScript("LearnAllSpellsWorld") {}
 
     void OnBeforeConfigLoad(bool reload) override
     {
-        if (!reload) {
+        if (!reload)
+        {
             std::string conf_path = _CONF_DIR;
             std::string cfg_file = conf_path + "/mod_learnspells.conf";
 #ifdef WIN32


### PR DESCRIPTION
- Adds a `LearnAllOnFirstLogin` (default: false) option to teach the
player all the spells when he first logs in, which is useful for instant leveling servers
- Disabled by default becasue of performance concerns,
- Slight optimizations have been added to mitigate this issue
- Works very fine on my dev machine (no noticable delay)
- However enabling this on a more populous server could cause issues
due to the current design.

*WARNING* relies on https://github.com/azerothcore/azerothcore-wotlk/pull/2793 being merged. Do not merge without it or else all the spells you will learn will be gone the next time the player logs in. 