### PR TITLE
Remove deprecated function/method calls

### DIFF
--- a/src/mod_learnspells.cpp
+++ b/src/mod_learnspells.cpp
@@ -29,7 +29,7 @@ public:
     {
         if (sConfigMgr->GetOption<bool>("LearnSpells.Enable", true))
         {
-            if (player->getLevel() <= sConfigMgr->GetOption<uint8>("LearnSpells.MaxLevel", 80) && oldLevel < player->getLevel())
+            if (player->GetLevel() <= sConfigMgr->GetOption<uint8>("LearnSpells.MaxLevel", 80) && oldLevel < player->GetLevel())
                 LearnSpellsForNewLevel(player, oldLevel);
         }
     }
@@ -402,7 +402,7 @@ private:
 
     void LearnSpellsForNewLevel(Player* player, uint8 fromLevel)
     {
-        uint8 upToLevel = player->getLevel();
+        uint8 upToLevel = player->GetLevel();
         uint32 family = GetSpellFamily(player);
 
         for (int level = fromLevel; level <= upToLevel; level++)


### PR DESCRIPTION
This fixes for the deprecation of `getLevel()` in https://github.com/azerothcore/azerothcore-wotlk/commit/21f86d1c3c0d48ca8f31c6d6f29005fe492a9a2e